### PR TITLE
Improve websocket reconnect mechanism

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val root = project.in( file( "." ) )
     .settings(
         aggregate in tut := false,
         autoScalaLibrary := false,
-        description := "An OkHttp wrapper for Scala",
+        description := "A monix wrapper for OkHttp",
         fork in tut := true,
         name := "communicator",
         managedSources := Seq.empty,

--- a/phoenix/src/test/scala/io/taig/communicator/phoenix/PhoenixTest.scala
+++ b/phoenix/src/test/scala/io/taig/communicator/phoenix/PhoenixTest.scala
@@ -52,9 +52,9 @@ class PhoenixTest extends Suite {
         val topic = Topic( "echo", "foobar" )
 
         val phoenix = Phoenix(
-            WebSocket(
+            WebSocket.fromRequest(
                 request,
-                failureReconnect = Some( 500 milliseconds )
+                errorReconnect = _ ⇒ Some( 500 milliseconds )
             )
         )
         val channel = Channel.join( topic )( phoenix )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
         val classic = java( "classic" )
     }
 
-    object monix extends Configuration( "io.monix", "monix", "2.2.1" ) {
+    object monix extends Configuration( "io.monix", "monix", "2.2.2" ) {
         val cats = scala( "cats" )
 
         val eval = scala( "eval" )

--- a/websocket/src/main/scala/io/taig/communicator/websocket/Default.scala
+++ b/websocket/src/main/scala/io/taig/communicator/websocket/Default.scala
@@ -3,7 +3,7 @@ package io.taig.communicator.websocket
 import scala.concurrent.duration._
 
 object Default {
-    val failureReconnect: Option[FiniteDuration] = None
+    val errorReconnect: Option[FiniteDuration] = None
 
     val completeReconnect: Option[FiniteDuration] = None
 }

--- a/websocket/src/main/scala/io/taig/communicator/websocket/Reconnect.scala
+++ b/websocket/src/main/scala/io/taig/communicator/websocket/Reconnect.scala
@@ -1,0 +1,5 @@
+package io.taig.communicator.websocket
+
+import scala.concurrent.duration.FiniteDuration
+
+private case class Reconnect( delay: FiniteDuration ) extends Exception

--- a/websocket/src/test/scala/io/taig/communicator/websocket/WebSocketTest.scala
+++ b/websocket/src/test/scala/io/taig/communicator/websocket/WebSocketTest.scala
@@ -101,4 +101,12 @@ class WebSocketTest extends Suite {
             _ should contain theSameElementsAs List( 1, 2 )
         }
     }
+
+    it should "release resources when stopped early" in {
+        WebSocket( request ).collect {
+            case WebSocket.Event.Open( socket ) ⇒ socket
+        }.firstL.runAsync.map {
+            _.close( 1000, null ) shouldBe false
+        }
+    }
 }

--- a/websocket/src/test/scala/io/taig/communicator/websocket/WebSocketTest.scala
+++ b/websocket/src/test/scala/io/taig/communicator/websocket/WebSocketTest.scala
@@ -6,7 +6,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 class WebSocketTest extends Suite {
-    it should "open a connection" in {
+    it should "start a connection" in {
         WebSocket( request ).firstL.runAsync.map {
             _ shouldBe WebSocket.Event.Connecting
         }
@@ -45,49 +45,49 @@ class WebSocketTest extends Suite {
     it should "reconnect after failure" in {
         var count = 0
 
-        WebSocket(
+        WebSocket.fromRequest(
             request,
-            failureReconnect = Some( 100 milliseconds )
+            errorReconnect = _ ⇒ Some( 100 milliseconds )
         ).collect {
-                case WebSocket.Event.Open( socket ) ⇒
-                    socket.cancel()
-                    count += 1
-                    count
-            }.take( 2 ).toListL.timeout( 10 seconds ).runAsync.map {
-                _ should contain theSameElementsAs List( 1, 2 )
-            }
+            case WebSocket.Event.Open( socket ) ⇒
+                socket.cancel()
+                count += 1
+                count
+        }.take( 2 ).toListL.timeout( 10 seconds ).runAsync.map {
+            _ should contain theSameElementsAs List( 1, 2 )
+        }
     }
 
     it should "reconnect after complete" in {
         var count = 0
 
-        WebSocket(
+        WebSocket.fromRequest(
             request,
-            completeReconnect = Some( 100 milliseconds )
+            completeReconnect = _ ⇒ Some( 100 milliseconds )
         ).collect {
-                case WebSocket.Event.Open( socket ) ⇒
-                    socket.close( 1000, null )
-                    count += 1
-                    count
-            }.take( 2 ).toListL.timeout( 10 seconds ).runAsync.map {
-                _ should contain theSameElementsAs List( 1, 2 )
-            }
+            case WebSocket.Event.Open( socket ) ⇒
+                socket.close( 1000, null )
+                count += 1
+                count
+        }.take( 2 ).toListL.timeout( 10 seconds ).runAsync.map {
+            _ should contain theSameElementsAs List( 1, 2 )
+        }
     }
 
     it should "not reconnect when cancelled explicitly" in {
         var count = 0
 
-        val observable = WebSocket(
+        val observable = WebSocket.fromRequest(
             request,
-            failureReconnect  = Some( 100 milliseconds ),
-            completeReconnect = Some( 100 milliseconds )
+            errorReconnect    = _ ⇒ Some( 100 milliseconds ),
+            completeReconnect = _ ⇒ Some( 100 milliseconds )
         ).publish
 
         val subscription = observable.connect()
 
         observable.collect {
             case WebSocket.Event.Open( socket ) ⇒
-                if ( count == 0 ) {
+                if ( count < 1 ) {
                     socket.close( 1000, null )
                 }
 
@@ -105,8 +105,9 @@ class WebSocketTest extends Suite {
     it should "release resources when stopped early" in {
         WebSocket( request ).collect {
             case WebSocket.Event.Open( socket ) ⇒ socket
-        }.firstL.runAsync.map {
-            _.close( 1000, null ) shouldBe false
+        }.firstL.runAsync.map { socket ⇒
+            Thread.sleep( 500 )
+            socket.close( 1000, null ) shouldBe false
         }
     }
 }


### PR DESCRIPTION
- Allow to pass a `Task[OkHttpRequest]` rather than just an `OkHttpRequest`, which will be reevaluated on every reconnect
- If the Task itself fails it triggers the reconnect mechanism
- Reconnect now allows to specify max reconnects or to implement exponential back offs